### PR TITLE
Revert "Bump vite from 5.4.11 to 5.4.14 in /skill-typing-front"

### DIFF
--- a/skill-typing-front/package-lock.json
+++ b/skill-typing-front/package-lock.json
@@ -22,7 +22,7 @@
         "postcss": "^8.4.49",
         "tailwindcss": "^3.4.16",
         "typescript": "^5.7.2",
-        "vite": "^5.4.14",
+        "vite": "^5.4.11",
         "vite-tsconfig-paths": "^5.1.4"
       }
     },
@@ -4887,9 +4887,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.14",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
-      "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
+      "version": "5.4.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.11.tgz",
+      "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/skill-typing-front/package.json
+++ b/skill-typing-front/package.json
@@ -25,7 +25,7 @@
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.16",
     "typescript": "^5.7.2",
-    "vite": "^5.4.14",
+    "vite": "^5.4.11",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }


### PR DESCRIPTION
Reverts Winter-Hackathon-2025-A-Team/skill-typing-front#9
間違えてmainにマージしてしまいました