### PR TITLE
管理画面の修正

### DIFF
--- a/skill-typing-front/app/routes/createQ.tsx
+++ b/skill-typing-front/app/routes/createQ.tsx
@@ -91,7 +91,7 @@ const App = () => {
         className="placeholder-opacity-50 mx-auto flex w-1/4 border-b py-2 placeholder-gray-500 focus:border-b-2 focus:border-blue-500 focus:outline-none"
       />
 
-      <p className="text-center text-gray-700">単語</p>
+      <p className="mt-4 text-center text-gray-700">単語</p>
       <input
         type="text"
         value={word}

--- a/skill-typing-front/app/routes/management.tsx
+++ b/skill-typing-front/app/routes/management.tsx
@@ -22,6 +22,12 @@ const app = () => {
       >
         問題編集
       </button>
+      <button
+        onClick={() => handleNavigate("/")}
+        className="boder relative mt-10 inline-block rounded-full border-gray-400 bg-blue-600 px-14 py-2 font-semibold text-white hover:bg-blue-500 active:bottom-[-1px]"
+      >
+        ホームへ戻る
+      </button>
     </div>
   );
 };


### PR DESCRIPTION
@Takahito-Uchinoさん @Koujirou513さん 
以下の修正を行いました。
・管理画面に「ホームへ戻る」ボタンを追加し、skill typingを押してもホームへ戻るボタンを押してもホームへ戻れるようにしました。
・問題作成画面で縦方向の位置(間隔)を調整しました。
(雑キャプチャでごめんなさい...)
<img width="1083" alt="スクリーンショット 2025-02-28 12 42 52" src="https://github.com/user-attachments/assets/09a4058c-d445-4a3a-9b3b-6f5be8223802" />
<img width="418" alt="スクリーンショット 2025-02-28 12 43 59" src="https://github.com/user-attachments/assets/cea11e05-adb3-4b57-a447-4206d5b66ae7" />

